### PR TITLE
Check PSRCHIVE API for multi-version compatability

### DIFF
--- a/pplib.py
+++ b/pplib.py
@@ -1011,7 +1011,7 @@ def make_constant_portrait(archive, outfile, profile=None, DM=0.0, dmc=False,
     try:
         arch = pr.Archive_load(archive)
     except AttributeError:
-        arch = psr.Archive.load(archive)
+        arch = pr.Archive.load(archive)
     # If both fail, something is wrong with the PSRCHIVE python install
 
     nsub, npol, nchan, nbin = arch.get_data().shape
@@ -2773,7 +2773,7 @@ def load_data(filename, state=None, dedisperse=False, dededisperse=False,
     try:
         arch = pr.Archive_load(filename)
     except AttributeError:
-        arch = psr.Archive.load(filename)
+        arch = pr.Archive.load(filename)
     # If both fail, something is wrong with the PSRCHIVE python install
 
     source = arch.get_source()

--- a/pplib.py
+++ b/pplib.py
@@ -1008,7 +1008,12 @@ def make_constant_portrait(archive, outfile, profile=None, DM=0.0, dmc=False,
         as weights.
     quiet=True suppresses output.
     """
-    arch = pr.Archive_load(archive)
+    try:
+        arch = pr.Archive_load(archive)
+    except AttributeError:
+        arch = psr.Archive.load(archive)
+    # If both fail, something is wrong with the PSRCHIVE python install
+
     nsub, npol, nchan, nbin = arch.get_data().shape
     if profile is None:
         arch.tscrunch()
@@ -2765,7 +2770,12 @@ def load_data(filename, state=None, dedisperse=False, dededisperse=False,
     quiet=True suppresses output.
     """
     # Load archive
-    arch = pr.Archive_load(filename)
+    try:
+        arch = pr.Archive_load(filename)
+    except AttributeError:
+        arch = psr.Archive.load(filename)
+    # If both fail, something is wrong with the PSRCHIVE python install
+
     source = arch.get_source()
     if not quiet:
         print("\nReading data from %s on source %s..." % (filename, source))

--- a/pptoas.py
+++ b/pptoas.py
@@ -1208,11 +1208,17 @@ class GetTOAs(object):
         else:
             datafiles = [datafile]
         if self.is_FITS_model:
-            model_arch = pr.Archive_load(self.modelfile)
+            try:
+                model_arch = pr.Archive_load(self.modelfile)
+            except AttributeError:
+                model_arch = pr.Archive.load(self.modelfile)
             model_arch.pscrunch()
             arrtim.set_standard(model_arch)
         for iarch, datafile in enumerate(datafiles):
-            arch = pr.Archive_load(datafile)
+            try:
+                arch = pr.Archive_load(datafile)
+            except AttributeError:
+                arch = pr.Archive.load(datafile)
             arch.pscrunch()
             if tscrunch: arch.tscrunch()
             arrtim.set_observation(arch)


### PR DESCRIPTION
The Archive loading API in psrchive has changed, thus to support older and modern versions, I've added a simple try-catch gate to code where the older `psrchive.Archive_load()` function was called, follwoing the Pythonic idiom "Ask for forgiveness rather than permission."

If both `psrchive.Archive_load` and `psrchive.Archive.load` fail, then something is wrong and we want early termination, thus the exception isn't handled and will just raise globally. 